### PR TITLE
Grafana up to 7.3.6

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,12 @@
 version: '3'
 services:
   grafana:
-    image: grafana/grafana:6.6.2
+    image: grafana/grafana:7.3.6
     ports:
       - "3000:3000"
     environment:
       GF_LOG_LEVEL: debug
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: hadesarchitect-cassandra-datasource
     volumes:
       - /var/lib/grafana
       - .:/var/lib/grafana/plugins/cassandra


### PR DESCRIPTION
- raises grafana version to 7.3.6
- Allows unsigned plugin